### PR TITLE
fix: reload manifest on start, detect port conflicts, add hook retries

### DIFF
--- a/src/daemon/env-daemon.ts
+++ b/src/daemon/env-daemon.ts
@@ -156,6 +156,9 @@ interface ManagedEnvironment {
 
 const environments = new Map<string, ManagedEnvironment>()
 
+/** Per-environment operation locks to prevent concurrent start/stop races. */
+const envLocks = new Map<string, Promise<void>>()
+
 /** Write current service state to the environment's state.json */
 function persistState(env: ManagedEnvironment): void {
   const envDir = env.manifest.paths?.root
@@ -701,7 +704,74 @@ function unregisterEnvironment(envId: string): boolean {
   return true
 }
 
+/**
+ * Check if any assigned ports are already in use — by another Colony
+ * environment or by any other process on the machine.
+ * Logs warnings so the user knows why services may fail or why preStart
+ * hooks will kill existing processes.
+ */
+async function checkPortConflicts(envId: string, manifest: InstanceManifest): Promise<void> {
+  const ports = manifest.ports
+  if (!ports) return
+
+  for (const [slot, port] of Object.entries(ports)) {
+    if (port == null) continue
+    const portNum = typeof port === 'string' ? parseInt(port, 10) : port
+    if (!portNum || isNaN(portNum)) continue
+
+    // First check: is it owned by another Colony environment?
+    let isColonyConflict = false
+    for (const [otherId, otherEnv] of environments) {
+      if (otherId === envId) continue
+      for (const [svcName, svc] of otherEnv.services) {
+        const svcPort = svc.resolved?.port != null ? parseInt(String(svc.resolved.port), 10) : null
+        if (svcPort === portNum && svc.pid != null && svc.status === 'running') {
+          log(`[${manifest.name}] ⚠ PORT CONFLICT: port ${portNum} (${slot}) is in use by Colony environment ${otherEnv.manifest.name}/${svcName} (pid ${svc.pid}). The preStart hook may kill it.`)
+          isColonyConflict = true
+        }
+      }
+    }
+
+    // Second check: is anything listening on the port? (catches non-Colony processes)
+    if (!isColonyConflict) {
+      const inUse = await checkPortTcp(portNum)
+      if (inUse) {
+        log(`[${manifest.name}] ⚠ PORT CONFLICT: port ${portNum} (${slot}) is in use by a non-Colony process. The preStart hook may kill it.`)
+      }
+    }
+  }
+}
+
+/** Re-read instance.json from disk and update in-memory state so edits are picked up. */
+function reloadManifestFromDisk(envId: string): void {
+  const env = environments.get(envId)
+  if (!env) return
+  const envDir = env.manifest.paths?.root
+  if (!envDir) return
+  const manifestPath = path.join(envDir, 'instance.json')
+  try {
+    const fresh = JSON.parse(fs.readFileSync(manifestPath, 'utf-8')) as InstanceManifest
+    registerEnvironment(fresh)
+    log(`[${fresh.name}] reloaded manifest from disk`)
+  } catch (err) {
+    log(`[${envId}] failed to reload manifest from disk: ${err}`)
+  }
+}
+
 async function startEnvironment(envId: string, serviceNames?: string[]): Promise<void> {
+  // Serialize per-environment to prevent concurrent start/stop races
+  const prev = envLocks.get(envId) ?? Promise.resolve()
+  const current = prev.then(() => startEnvironmentImpl(envId, serviceNames)).finally(() => {
+    if (envLocks.get(envId) === current) envLocks.delete(envId)
+  })
+  envLocks.set(envId, current.catch(() => {}))
+  return current
+}
+
+async function startEnvironmentImpl(envId: string, serviceNames?: string[]): Promise<void> {
+  // Re-read manifest from disk so any edits to instance.json are picked up
+  reloadManifestFromDisk(envId)
+
   const env = environments.get(envId)
   if (!env) throw new Error(`environment ${envId} not found`)
 
@@ -717,6 +787,10 @@ async function startEnvironment(envId: string, serviceNames?: string[]): Promise
     allServices[name] = env.services.get(name)!.def
   }
   const waves = topoSort(allServices)
+
+  // Detect port conflicts with other Colony environments before preStart hooks
+  // (preStart hooks may blindly kill processes on assigned ports)
+  await checkPortConflicts(envId, manifest)
 
   // Run preStart hooks before spawning any services
   await runHooks(manifest, 'preStart')

--- a/src/daemon/env-protocol.ts
+++ b/src/daemon/env-protocol.ts
@@ -49,6 +49,8 @@ export interface HookStep {
   name: string
   interactive?: boolean
   continueOnError?: boolean    // If true, failure doesn't block subsequent hooks
+  retries?: number             // Number of times to retry on failure (default: 0, max: 5)
+  retryDelayMs?: number        // Delay between retries in ms (default: 5000, max: 30000)
 }
 
 export interface SetupStep {

--- a/src/main/env-setup.ts
+++ b/src/main/env-setup.ts
@@ -194,24 +194,36 @@ export async function runSetup(
       })
       logSetup(`  Hook: ${hook.name} -- ${cmd.slice(0, 80)}`)
       updateStep(hook.name, 'running')
-      try {
-        const output = await execAsync(cmd, { cwd: hook.cwd || envDir, timeout: 300000 })
-        const trimmed = output?.trim() || ''
-        if (trimmed) logSetup(`  Output: ${trimmed.slice(0, 500)}`)
-        const lastLine = trimmed.split('\n').pop()?.trim() || ''
-        if (lastLine) {
-          const key = (hook.name as string).replace(/-/g, '_')
-          hookOutputs[key] = lastLine
-          hookOutputs[hook.name] = lastLine
-        }
-        updateStep(hook.name, 'done')
-        logSetup(`  Done: ${hook.name}`)
-      } catch (err: any) {
-        const stderr = err.stderr ? `\nStderr: ${err.stderr.slice(0, 500)}` : ''
-        logSetup(`  FAILED: ${hook.name} -- ${String(err).slice(0, 300)}${stderr}`)
-        updateStep(hook.name, 'error', String(err).slice(0, 300), { continueOnError: !!hook.continueOnError })
-        if (hook.continueOnError) {
-          logSetup(`  (continueOnError: proceeding despite failure)`)
+
+      const maxRetries = Math.min(hook.retries ?? 0, 5)
+      const retryDelay = Math.min(hook.retryDelayMs ?? 5000, 30000)
+
+      for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        try {
+          const output = await execAsync(cmd, { cwd: hook.cwd || envDir, timeout: 300000 })
+          const trimmed = output?.trim() || ''
+          if (trimmed) logSetup(`  Output: ${trimmed.slice(0, 500)}`)
+          const lastLine = trimmed.split('\n').pop()?.trim() || ''
+          if (lastLine) {
+            const key = (hook.name as string).replace(/-/g, '_')
+            hookOutputs[key] = lastLine
+            hookOutputs[hook.name] = lastLine
+          }
+          updateStep(hook.name, 'done')
+          logSetup(`  Done: ${hook.name}`)
+          return  // success — exit retry loop
+        } catch (err: any) {
+          if (attempt < maxRetries) {
+            logSetup(`  Hook ${hook.name} failed (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${retryDelay}ms...`)
+            await new Promise(r => setTimeout(r, retryDelay))
+            continue
+          }
+          const stderr = err.stderr ? `\nStderr: ${err.stderr.slice(0, 500)}` : ''
+          logSetup(`  FAILED: ${hook.name} -- ${String(err).slice(0, 300)}${stderr}`)
+          updateStep(hook.name, 'error', String(err).slice(0, 300), { continueOnError: !!hook.continueOnError })
+          if (hook.continueOnError) {
+            logSetup(`  (continueOnError: proceeding despite failure)`)
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

Three fixes for environment daemon reliability, discovered while diagnosing setup failures across multiple concurrent environments.

- **Daemon re-reads instance.json on start** — previously `colony start` used stale in-memory config, silently ignoring edits to `instance.json`. Now `startEnvironment()` calls `reloadManifestFromDisk()` before spawning services. This was the root cause of service commands not updating after config changes.

- **Port conflict detection** — before running `preStart` hooks (which may blindly `kill -9` processes on assigned ports), the daemon now checks if any assigned ports are in use by another Colony environment and logs a warning with the conflicting env name, service, and PID. Previously this caused silent data loss when one environment's preStart hook killed another environment's running services.

- **Setup hook retries** — hooks can now specify `retries` and `retryDelayMs` in the template to auto-retry on transient failures. This addresses the `ensure-infra` hook failing when `docker compose --wait` times out on slow MinIO health checks — a consistent blocker for fresh environment setup. Backward-compatible: hooks without `retries` behave exactly as before.

## How it was validated

- Built and deployed to a local Colony instance managing 2 environments (env-1 and env-2)
- Edited env-2's `instance.json` to add `--port 8022` to the frontend command
- Ran `colony stop` + `colony start` — daemon picked up the change (previously required manual re-register via socket)
- Both environments running on correct ports with all core services healthy
- Existing tests pass (`env-setup-hook-order.test.ts`)

## Follow-up items (newton template, not this PR)

- The `ensure-infra` hook should use `retries: 2` + `continueOnError: true` to handle MinIO health check flakiness
- The frontend command should use `yarn vite --port ${ports.frontend}` instead of relying on `VITE_PORT` env var (Vite ignores it)
- The `create-database` hook should guard against "already exists" for idempotent retries

## Test plan

- [ ] Verify `npx tsc --noEmit` passes (confirmed locally)
- [ ] Verify existing tests pass: `npx vitest run src/main/__tests__/env-setup-hook-order.test.ts`
- [ ] Create a fresh environment and confirm setup succeeds
- [ ] Edit `instance.json`, run `colony start`, confirm new config is used
- [ ] Start two environments with overlapping ports and check daemon logs for conflict warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)