### PR TITLE
feat: add authored-by and not-draft pipeline conditions

### DIFF
--- a/src/main/pipeline-engine.ts
+++ b/src/main/pipeline-engine.ts
@@ -59,6 +59,8 @@ export type LeafConditionType =
   | 'always'
   | 'files-changed'
   | 'review-requested'
+  | 'authored-by'
+  | 'not-draft'
 
 export type CompositeConditionType = 'any-of' | 'all-of'
 
@@ -978,6 +980,18 @@ function evaluateReviewRequested(condition: ConditionDef, ctx: TriggerContext): 
   return ctx.pr.reviewers.includes(ctx.githubUser)
 }
 
+function evaluateAuthoredBy(condition: ConditionDef, ctx: TriggerContext): boolean {
+  void condition
+  if (!ctx.pr || !ctx.githubUser) return false
+  return ctx.pr.author === ctx.githubUser
+}
+
+function evaluateNotDraft(condition: ConditionDef, ctx: TriggerContext): boolean {
+  void condition
+  if (!ctx.pr) return false
+  return !ctx.pr.draft
+}
+
 // ---- Composite Condition Helpers ----
 
 const COMPOSITE_CONDITION_TYPES = new Set<string>(['any-of', 'all-of'])
@@ -1039,6 +1053,8 @@ async function evaluateLeafCondition(condition: ConditionDef, ctx: TriggerContex
     case 'pr-checks-failed': return evaluatePrChecksFailed(condition, ctx)
     case 'files-changed': return evaluateFilesChanged(condition, ctx)
     case 'review-requested': return evaluateReviewRequested(condition, ctx)
+    case 'authored-by': return evaluateAuthoredBy(condition, ctx)
+    case 'not-draft': return evaluateNotDraft(condition, ctx)
     case 'always': return true
     default: return false
   }


### PR DESCRIPTION
## Summary

Adds two new leaf condition types for pipeline git-poll triggers:

- **`authored-by`** — matches PRs where the author is the configured GitHub user
- **`not-draft`** — matches PRs that are not in draft state

These enable precise per-author pipeline filtering without launching LLM sessions for every open PR in the repo.

## Motivation

When using `git-poll` + `route-to-session` for a "My PRs" lifecycle pipeline, `condition: type: always` fires for ALL open PRs in the repo. This wastes LLM calls on other authors' PRs (the session launches, checks the author in the prompt, and exits). With `authored-by`, the engine filters at the GitHub level — zero sessions launched for PRs that aren't yours.

## Usage

```yaml
# Single condition
condition:
  type: authored-by

# Composed with all-of
condition:
  type: all-of
  conditions:
    - type: authored-by
    - type: not-draft
```

## Changes

- `src/main/pipeline-engine.ts`: 16 lines added
  - Added `authored-by` and `not-draft` to `LeafConditionType` union
  - Added `evaluateAuthoredBy()` and `evaluateNotDraft()` functions (follows `evaluateReviewRequested` pattern)
  - Added cases to `evaluateLeafCondition` switch

## Test plan

- [ ] Create a pipeline with `condition: type: authored-by` and verify it only fires for PRs authored by the configured user
- [ ] Create a pipeline with `condition: type: not-draft` and verify it skips draft PRs
- [ ] Verify `all-of` composition works: `authored-by` + `not-draft`
- [ ] Verify existing conditions (`always`, `review-requested`, `pr-checks-failed`) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)